### PR TITLE
Added Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,52 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
-language: R
+###### Default build via devtools::use_travis()
+
+language: r
 sudo: false
 cache: packages
-after_success:
-  - Rscript -e 'covr::codecov()'
+
+###### Custom Options
+
+# Containers have 2 CPUs by default. Speed up the build by using both.
+# c.f. https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
+env:
+  global:
+  - MAKEFLAGS="-j 2"
+  - _R_CHECK_FORCE_SUGGESTS=0
+
+# Enable a build matrix that individually tests the package against the
+# appropriate operating systems.
+matrix:
+    include:
+        - os: linux
+          r: oldrel
+        - os: linux
+          r: release
+          r_packages:
+            - covr
+          after_success:
+            - Rscript -e 'covr::codecov(quiet=FALSE)'
+        - os: linux
+          r: devel
+          env:
+              - _R_CHECK_LENGTH_1_CONDITION_=package:_R_CHECK_PACKAGE_NAME_,abort,verbose
+              - _R_S3_METHOD_LOOKUP_BASEENV_AFTER_GLOBALENV_=true
+              - _R_S3_METHOD_LOOKUP_USE_TOPENV_AS_DEFENV_=true
+        - os: osx
+          r: oldrel
+        - os: osx
+          r: release
+        - os: osx
+          r: devel
+
+# Enable a fast finish if any job in the matrix fails.
+# c.f. https://blog.travis-ci.com/2013-11-27-fast-finishing-builds
+matrix:
+  - fast_finish: true
+
+# Set notification options
+notifications:
+  email:
+    on_success: change
+    on_failure: change

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ecdm
 Title: Exploratory Cognitative Diagnostic Models
-Version: 0.0.4
+Version: 0.0.5
 Authors@R: c(
     person("James", "Balamuta", email = "balamut2@illinois.edu", 
            role = c("aut", "cre", "cph"), 


### PR DESCRIPTION
Provides test coverage for the majority of R releases.

At the time of writing these are: `oldrel`: 3.4.4, `release`: 3.5.1, `devel`: nightly r-devel builds.
